### PR TITLE
feat: metadata based custom nav

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -1,4 +1,4 @@
-import { readBlockConfig, decorateIcons } from '../../scripts/lib-franklin.js';
+import { decorateIcons, getMetadata } from '../../scripts/lib-franklin.js';
 import { decorateLangSwitcher } from '../../scripts/scripts.js';
 
 // media query match that indicates mobile/tablet width
@@ -91,11 +91,10 @@ function toggleMenu(nav, navSections, forceExpanded = null) {
  * @param {Element} block The header block element
  */
 export default async function decorate(block) {
-  const config = readBlockConfig(block);
   block.textContent = '';
 
   // fetch nav content
-  const navPath = config.nav || '/nav';
+  const navPath = getMetadata('nav').trim() || '/nav';
   const resp = await fetch(`${navPath}.plain.html`);
 
   if (resp.ok) {


### PR DESCRIPTION
Loads a custom nav based on the page's metadata. This can be set on the page itself, or globally via [metadata sheet](https://www.hlx.live/docs/bulk-metadata).

Test URLs:
- Before: https://main--merkle-franklin--hlxsites.hlx.page/logo/
- After: https://custom-nav--merkle-franklin--hlxsites.hlx.page/logo/
